### PR TITLE
Add tests for weather DAG helper functions

### DIFF
--- a/tests/test_weather_dag.py
+++ b/tests/test_weather_dag.py
@@ -1,0 +1,95 @@
+import datetime
+import importlib
+
+import pytest
+from airflow.models import Variable
+
+
+@pytest.fixture
+def weather_dag(monkeypatch):
+    monkeypatch.setattr(Variable, "get", lambda key: "test_api_key")
+    import dags.weather_dag as module
+
+    importlib.reload(module)
+    return module
+
+
+def test_process_weather_maps_expected_fields(weather_dag):
+    payload = {
+        "data": [
+            {
+                "dt": 1700000000,
+                "temp": 12.3,
+                "clouds": 45,
+                "humidity": 67,
+                "wind_speed": 5.4,
+            }
+        ]
+    }
+
+    class DummyTI:
+        def xcom_pull(self, *args, **kwargs):
+            return payload
+
+    result = weather_dag.process_weather({"city": "Kyiv"}, DummyTI())
+
+    assert result == {
+        "execution_time": 1700000000,
+        "temperature": 12.3,
+        "humidity": 45,
+        "cloudiness": 67,
+        "wind_speed": 5.4,
+    }
+
+
+def test_create_table_runs_expected_sql(weather_dag, monkeypatch):
+    captured = {}
+
+    class DummyPostgresHook:
+        def __init__(self, postgres_conn_id):
+            captured["postgres_conn_id"] = postgres_conn_id
+
+        def run(self, sql):
+            captured["sql"] = sql
+
+    monkeypatch.setattr(weather_dag, "PostgresHook", DummyPostgresHook)
+
+    weather_dag.create_table()
+
+    assert captured["postgres_conn_id"] == "pg_conn"
+    assert "CREATE TABLE IF NOT EXISTS measures" in captured["sql"]
+
+
+def test_extract_weather_data_builds_request(weather_dag, monkeypatch):
+    captured = {}
+
+    class DummyResponse:
+        def json(self):
+            return {"status": "ok"}
+
+    class DummyHttpHook:
+        def __init__(self, method, http_conn_id):
+            captured["method"] = method
+            captured["http_conn_id"] = http_conn_id
+
+        def run(self, endpoint, data):
+            captured["endpoint"] = endpoint
+            captured["data"] = data
+            return DummyResponse()
+
+    monkeypatch.setattr(weather_dag, "HttpHook", DummyHttpHook)
+
+    execution_date = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    result = weather_dag.extract_weather_data(
+        {"lat": "1.23", "lon": "4.56"}, execution_date
+    )
+
+    assert result == {"status": "ok"}
+    assert captured["method"] == "GET"
+    assert captured["http_conn_id"] == "weather_api_conn"
+    assert captured["endpoint"] == "data/3.0/onecall/timemachine?"
+    assert captured["data"]["appid"] == "test_api_key"
+    assert captured["data"]["lat"] == "1.23"
+    assert captured["data"]["lon"] == "4.56"
+    assert captured["data"]["dt"] == int(execution_date.timestamp())
+    assert captured["data"]["units"] == "metric"


### PR DESCRIPTION
### Motivation

- Add unit tests to validate the helper functions in the `dags/weather_dag.py` DAG to improve reliability.  
- Ensure behavior of data processing, SQL table creation, and API request construction is covered.  
- Keep tests isolated from external services by mocking Airflow hooks and variables.  

### Description

- Add `tests/test_weather_dag.py` with tests `test_process_weather_maps_expected_fields`, `test_create_table_runs_expected_sql`, and `test_extract_weather_data_builds_request`.  
- Mock `Variable.get` to provide a test API key and reload the module with `importlib.reload` to apply the monkeypatch.  
- Replace `PostgresHook` and `HttpHook` with dummy classes in tests to capture SQL and request parameters without calling external services.  

### Testing

- New pytest test file `tests/test_weather_dag.py` was created and committed to the repository.  
- No automated test runner (e.g., `pytest`) was executed during this rollout, so test results are not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d5d8e64ec8327ab98cda7dd8c1c88)